### PR TITLE
Enable sublass SBPickerSelector

### DIFF
--- a/SBPickerSelector/Source/SBPickerSelector.h
+++ b/SBPickerSelector/Source/SBPickerSelector.h
@@ -64,8 +64,8 @@ typedef NS_ENUM(NSInteger, SBPickerSelectorDateType) {
 @property (nonatomic, strong) NSString *cancelButtonTitle;
 
 
-+ (SBPickerSelector *) picker;
-+ (SBPickerSelector *) pickerWithNibName:(NSString*)nibName;
++ (instancetype) picker;
++ (instancetype) pickerWithNibName:(NSString*)nibName;
 - (void) showPickerIpadFromRect:(CGRect)rect inView:(UIView *)view;
 - (void) showPickerOver:(UIViewController *)parent;
 

--- a/SBPickerSelector/Source/SBPickerSelector.m
+++ b/SBPickerSelector/Source/SBPickerSelector.m
@@ -11,12 +11,12 @@
 
 @implementation SBPickerSelector
 
-+ (SBPickerSelector *) picker {
-    return [SBPickerSelector pickerWithNibName:@"SBPickerSelector"];
++ (instancetype) picker {
+    return [self pickerWithNibName:@"SBPickerSelector"];
 }
 
-+ (SBPickerSelector *) pickerWithNibName:(NSString*)nibName {
-    SBPickerSelector *instance = [[SBPickerSelector alloc] initWithNibName:nibName bundle:nil];
++ (instancetype) pickerWithNibName:(NSString*)nibName {
+    SBPickerSelector *instance = [[self alloc] initWithNibName:nibName bundle:nil];
     instance.pickerData = [NSMutableArray arrayWithCapacity:0];
     instance.numberOfComponents = 1;
     return instance;


### PR DESCRIPTION
I needed to subclass SBPickerSelector. Without this modifications I couldn't subclass it. 
